### PR TITLE
Fixed out of sync definitions for set_frequency_registers() and scale_uint32()

### DIFF
--- a/Firmware/radio/radio.c
+++ b/Firmware/radio/radio.c
@@ -52,8 +52,8 @@ __pdata struct radio_settings settings;
 static void	register_write(uint8_t reg, uint8_t value) __reentrant;
 static uint8_t	register_read(uint8_t reg);
 static bool	software_reset(void);
-static void	set_frequency_registers(uint32_t frequency);
-static uint32_t scale_uint32(uint32_t value, uint32_t scale);
+static void	set_frequency_registers(__pdata uint32_t frequency);
+static uint32_t scale_uint32(__pdata uint32_t value, __pdata uint32_t scale);
 static void	clear_status_registers(void);
 
 // save and restore radio interrupt. We use this rather than


### PR DESCRIPTION
This fixes this compile error:

```
make install
% install radio for hm_trp
CC radio/radio.c
radio/radio.c:1032: error 98: conflict with previous definition of 'scale_uint32' for attribute 'type'
from type 'unsigned-long-int function ( unsigned-long-int fixed, unsigned-long-int fixed) fixed'
  to type 'unsigned-long-int function ( unsigned-long-int pdata, unsigned-long-int pdata) fixed'
radio/radio.c:1082: error 98: conflict with previous definition of 'set_frequency_registers' for attribute 'type'
from type 'void function ( unsigned-long-int fixed) fixed'
  to type 'void function ( unsigned-long-int pdata) fixed'
make[1]: *** [obj/hm_trp/radio~hm_trp/radio.rel] Error 1
make: *** [install~radio~hm_trp] Error 2
```

With this SDCC version:

```
SDCC : mcs51/z80/z180/r2k/r3ka/gbz80/tlcs90/ds390/pic16/pic14/TININative/ds400/hc08/s08/stm8 3.4.0 #8981 (Aug 10 2014) (Mac OS X x86_64)
published under GNU General Public License (GPL)
```